### PR TITLE
Improve and fix oedatamodel datapackage jsons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IDE
+.vscode

--- a/oedatamodel/latest/v111/datapackage/OEDataModel-concrete-datapackage/OEDataModel-concrete-datapackage.json
+++ b/oedatamodel/latest/v111/datapackage/OEDataModel-concrete-datapackage/OEDataModel-concrete-datapackage.json
@@ -1,162 +1,459 @@
-{"name": "Oedatamodel readable - General Energy Modell Datapackage",
-"title": "OpenEnergyPlatform data format for scenario data in human readable format",
-"id": "",
-"description": "datamodel, metadata and examples provided as datapackage",
-"language": ["en-GB"],
-"keywords": ["datamodel", "datapackage", "genral energy dataformat"],
-"publicationDate": "2020-08-11",
-"context":
-    {"homepage": "https://openenergy-platform.org/",
-    "documentation": "https://github.com/OpenEnergyPlatform/oedatamodel/blob/develop/README.md",
-    "sourceCode": "https://github.com/OpenEnergyPlatform/oedatamodel/tree/develop/oedatamodel/latest",
-    "contact": "",
-    "grantNo": "",
-    "fundingAgency": "",
-    "fundingAgencyLogo": "",
-    "publisherLogo": ""},
-"spatial":
-    {"location": "",
-    "extent": "",
-    "resolution": ""},
-"temporal": 
-    {"referenceDate": "",
-    "timeseries": 
-        {"start": "",
-        "end": "",
-        "resolution": "",
-        "alignment": "",
-        "aggregationType": ""} },
-"sources": [
-    {
-        "title": "Open energy datamodel",
-        "description": "oedatamodel for energy model data",
-        "path": "https://github.com/OpenEnergyPlatform/oedatamodel/tree/develop/oedatamodel",
-        "licenses": [
-            {
-                "name": "CC0-1.0",
-                "title": "Creative Commons Zero v1.0 Universal",
-                "path": "https://creativecommons.org/publicdomain/zero/1.0/legalcode",
-                "instruction": "You are free: To Share, To Create, To Adapt",
-                "attribution": "© Reiner Lemoine Institut"
+{
+    "name": "Oedatamodel readable - General Energy Modell Datapackage",
+    "title": "OpenEnergyPlatform data format for scenario data in human readable format",
+    "id": null,
+    "description": "datamodel, metadata and examples provided as datapackage",
+    "language": [
+        "en-GB"
+    ],
+    "subject": [],
+    "keywords": [
+        "datamodel",
+        "datapackage",
+        "genral energy dataformat"
+    ],
+    "publicationDate": "2020-08-11",
+    "context": {
+        "homepage": "https://openenergy-platform.org/",
+        "documentation": "https://github.com/OpenEnergyPlatform/oedatamodel/blob/develop/README.md",
+        "sourceCode": "https://github.com/OpenEnergyPlatform/oedatamodel/tree/develop/oedatamodel/latest",
+        "contact": "tbd@tbd.de",
+        "grantNo": null,
+        "fundingAgency": null,
+        "fundingAgencyLogo": null,
+        "publisherLogo": null
+    },
+    "spatial": {
+        "location": null,
+        "extent": null,
+        "resolution": null
+    },
+    "temporal": {
+        "timeseries": []
+    },
+    "review": {
+        "path": null,
+        "badge": null
+    },
+    "sources": [
+        {
+            "title": "Open energy datamodel",
+            "description": "oedatamodel for energy model data",
+            "path": "https://github.com/OpenEnergyPlatform/oedatamodel/tree/develop/oedatamodel",
+            "licenses": [
+                {
+                    "instruction": "You are free: To Share, To Create, To Adapt",
+                    "attribution": "© Reiner Lemoine Institut",
+                    "name": "CC0-1.0",
+                    "title": "Creative Commons Zero v1.0 Universal",
+                    "path": "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
+                }
+            ]
+        }
+    ],
+    "licenses": [
+        {
+            "instruction": null,
+            "attribution": null,
+            "name": null,
+            "title": null,
+            "path": null
+        }
+    ],
+    "contributors": [
+        {
+            "title": "jh-RLI",
+            "object": "datapackage",
+            "comment": "Create template datapackage for oedatamodel",
+            "date": "2020-08-11"
+        },
+        {
+            "title": "jh-RLI",
+            "object": "metadata",
+            "comment": "Fix links to documentation and source code",
+            "date": "2020-10-08"
+        },
+        {
+            "title": "jh-RLI",
+            "object": "metadata",
+            "comment": "Update Ressources",
+            "date": "2020-11-08"
+        },
+        {
+            "title": "OMI",
+            "object": "Metadata conversion",
+            "comment": "Update metadata to oep-v1.5.1 using OMIs metadata conversion tool.",
+            "date": "2022-09-14"
+        }
+    ],
+    "resources": [
+        {
+            "profile": "tabular-data-resource",
+            "name": "oed_concrete_scenario",
+            "path": "OEDataModel-concrete_scenario.csv",
+            "format": "csv",
+            "encoding": "UTF-8",
+            "schema": {
+                "primaryKey": [
+                    "id"
+                ],
+                "foreignKeys": [],
+                "fields": [
+                    {
+                        "name": "id",
+                        "description": "Unique identifier",
+                        "type": "bigint",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "scenario",
+                        "description": "Scenario name",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "region",
+                        "description": "Country or region, you can add a upper region with sub regions using json syntax",
+                        "type": "json",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "year",
+                        "description": "Year",
+                        "type": "integer",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "source",
+                        "description": "Source",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "comment",
+                        "description": "Comment",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    }
+                ]
+            },
+            "dialect": {
+                "delimiter": ";",
+                "decimalSeparator": "."
             }
-        ]
-    }],
-"licenses": [
-    {
-        "name": "",
-        "title": "",
-        "path": "",
-        "instruction": "",
-        "attribution": ""
-    } 
-],
-"contributors": [
-    {"title": "jh-RLI", "email": null, "date": "2020-08-11", "object": "datapackage", "comment": "Create template datapackage for oedatamodel"},
-    {"title": "jh-RLI", "email": null, "date": "2020-10-08", "object": "metadata", "comment": "Fix links to documentation and source code"},
-    {"title": "jh-RLI", "email": null, "date": "2020-11-08", "object": "metadata", "comment": "Update Ressources"} ],
-"resources": [
-    {"profile": "tabular-data-resource",
-    "name": "oed_concrete_scenario",
-    "path": "OEDataModel-concrete_scenario.csv",
-    "format": "csv",
-    "encoding" : "UTF-8",
-    "schema": {
-        "fields": [
-            {"name": "id", "description": "Unique identifier", "type": "bigint", "unit": null},
-            {"name": "scenario", "description": "Scenario name", "type": "text", "unit": null},
-            {"name": "region", "description": "Country or region, you can add a upper region with sub regions using json syntax", "type": "json", "unit": null},
-            {"name": "year", "description": "Year", "type": "integer", "unit": null},
-            {"name": "source", "description": "Source", "type": "text", "unit": null},
-            {"name": "comment", "description": "Comment", "type": "text", "unit": null} ],
-        "primaryKey": ["id"],
-        "foreignKeys": [{
-                "fields": [null],
-                "reference": {
-                    "resource": null,
-                    "fields": [null] } } ] },
-    "dialect":
-        {"delimiter": ";",
-        "decimalSeparator": "."} },
-
-    {"profile": "tabular-data-resource",
-    "name": "oed_concrete_scalar",
-    "path": "OEDataModel-concrete_scalar.csv",
-    "format": "csv",
-    "encoding" : "UTF-8",
-    "schema": {
-        "fields": [
-            {"name": "id", "description": "Unique identifier", "type": "bigint", "unit": null},
-            {"name": "scenario_id", "description": "Scenario name", "type": "bigint", "unit": null},
-            {"name": "region", "description": "Country or region, add a flow from region a -> b: ['a', 'b']", "type": "text array", "unit": null},
-            {"name": "year", "description": "Year", "type": "integer", "unit": null},
-            {"name": "input_energy_vector", "description": "It describes any type of energy or energy carrier (e.g. electricity, heat, solar radiation, natural gas, ...) that enters a technology.", "type": "text", "unit": null},
-            {"name": "output_energy_vector", "description": "It describes any type of energy or energy carrier (e.g. electricity, heat, hydrogen, LNG, CO2, ...) that exits a technology.", "type": "text", "unit": null},
-            {"name": "parameter_name", "description": "It describes a considered property of an element in the energy system.", "type": "text", "unit": null},
-            {"name": "technology", "description": "It describes an element of the modelled energy system that processes an energy vector.", "type": "text", "unit": null},
-            {"name": "technology_type", "description": "The specification can be technological, or freely user-defined, based on the requirements of the model.", "type": "text", "unit": null},
-            {"name": "value", "description": "Parameter value", "type": "decimal", "unit": "kW"},
-            {"name": "unit", "description": "Parameter unit", "type": "text", "unit": null},
-            {"name": "tags", "description": "Free classification with key-value pairs", "type": "json", "unit": null},
-            {"name": "method", "description": "Method type (sum, mean, median)", "type": "json", "unit": null},
-            {"name": "source", "description": "Source", "type": "text", "unit": null},
-            {"name": "comment", "description": "Comment", "type": "text", "unit": null} ],
-        "primaryKey": ["id"],
-        "foreignKeys": [{
-                "fields": ["scenario_id"],
-                "reference": {
-                    "resource": "oed_concrete_scenari",
-                    "fields": ["id"] } } ] },
-    "dialect":
-        {"delimiter": ";",
-        "decimalSeparator": "."} },
-        {"profile": "tabular-data-resource",
+        },
+        {
+            "profile": "tabular-data-resource",
+            "name": "oed_concrete_scalar",
+            "path": "OEDataModel-concrete_scalar.csv",
+            "format": "csv",
+            "encoding": "UTF-8",
+            "schema": {
+                "primaryKey": [
+                    "id"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": [
+                            "scenario_id"
+                        ],
+                        "reference": {
+                            "resource": "oed_concrete_scenari",
+                            "fields": [
+                                "id"
+                            ]
+                        }
+                    }
+                ],
+                "fields": [
+                    {
+                        "name": "id",
+                        "description": "Unique identifier",
+                        "type": "bigint",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "scenario_id",
+                        "description": "Scenario name",
+                        "type": "bigint",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "region",
+                        "description": "Country or region, add a flow from region a -> b: ['a', 'b']",
+                        "type": "text array",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "year",
+                        "description": "Year",
+                        "type": "integer",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "input_energy_vector",
+                        "description": "It describes any type of energy or energy carrier (e.g. electricity, heat, solar radiation, natural gas, ...) that enters a technology.",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "output_energy_vector",
+                        "description": "It describes any type of energy or energy carrier (e.g. electricity, heat, hydrogen, LNG, CO2, ...) that exits a technology.",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "parameter_name",
+                        "description": "It describes a considered property of an element in the energy system.",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "technology",
+                        "description": "It describes an element of the modelled energy system that processes an energy vector.",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "technology_type",
+                        "description": "The specification can be technological, or freely user-defined, based on the requirements of the model.",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "value",
+                        "description": "Parameter value",
+                        "type": "decimal",
+                        "isAbout": [],
+                        "valueReference": [],
+                        "unit": "kW"
+                    },
+                    {
+                        "name": "unit",
+                        "description": "Parameter unit",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "tags",
+                        "description": "Free classification with key-value pairs",
+                        "type": "json",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "method",
+                        "description": "Method type (sum, mean, median)",
+                        "type": "json",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "source",
+                        "description": "Source",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "comment",
+                        "description": "Comment",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    }
+                ]
+            },
+            "dialect": {
+                "delimiter": ";",
+                "decimalSeparator": "."
+            }
+        },
+        {
+            "profile": "tabular-data-resource",
             "name": "oed_concrete_timeseries",
             "path": "OEDataModel-concrete_timeseries.csv",
             "format": "csv",
-            "encoding" : "UTF-8",
+            "encoding": "UTF-8",
             "schema": {
-                "fields": [
-                    {"name": "id", "description": "Unique identifier", "type": "bigint", "unit": null},
-                    {"name": "scenario_id", "description": "Scenario name", "type": "bigint", "unit": null},
-                    {"name": "region", "description": "Country or region", "type": "text array", "unit": null},
-                    {"name": "input_energy_vector", "description": "It describes any type of energy or energy carrier (e.g. electricity, heat, solar radiation, natural gas, ...) that enters a technology.", "type": "text", "unit": null},
-                    {"name": "output_energy_vector", "description": "It describes any type of energy or energy carrier (e.g. electricity, heat, hydrogen, LNG, CO2, ...) that exits a technology.", "type": "text", "unit": null},
-                    {"name": "parameter_name", "description": "It describes a considered property of an element in the energy system.", "type": "text", "unit": null},
-                    {"name": "technology", "description": "It describes an element of the modelled energy system that processes an energy vector.", "type": "text", "unit": null},
-                    {"name": "technology_type", "description": "The specification can be technological, or freely user-defined, based on the requirements of the model.", "type": "text", "unit": null},
-                    {"name": "timeindex_start", "description": "Start timestamp", "type": "timestamp", "unit": null},
-                    {"name": "timeindex_stop", "description": "Stop timestamp", "type": "timestamp", "unit": null},
-                    {"name": "timeindex_resolution", "description": "Timesteps", "type": "interval", "unit": null},
-                    {"name": "series", "description": "Timesteps", "type": "float array", "unit": null},
-                    {"name": "unit", "description": "Parameter unit", "type": "text", "unit": null},
-                    {"name": "tags", "description": "Free classification with key-value pairs", "type": "json", "unit": null},
-                    {"name": "method", "description": "Method type (sum, mean, median)", "type": "json", "unit": null},
-                    {"name": "source", "description": "Source", "type": "text", "unit": null},
-                    {"name": "comment", "description": "Comment", "type": "text", "unit": null} ],
-                "primaryKey": ["id"],
-                "foreignKeys": [{
-                        "fields": ["scenario_id"],
+                "primaryKey": [
+                    "id"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": [
+                            "scenario_id"
+                        ],
                         "reference": {
                             "resource": "oed_concrete_scenari",
-                            "fields": ["id"] } } ] },
-            "dialect":
-                {"delimiter": ";",
-                "decimalSeparator": "."} } ],
-
-"review": {
-    "path": "",
-    "badge": ""},
-"metaMetadata":
-    {"metadataVersion": "OEP-1.4.0",
-    "metadataLicense":
-        {"name": "CC0-1.0",
-        "title": "Creative Commons Zero v1.0 Universal",
-        "path": "https://creativecommons.org/publicdomain/zero/1.0/"} },
-"_comment":
-    {"metadata": "Metadata documentation and explanation (https://github.com/OpenEnergyPlatform/organisation/wiki/metadata)",
-    "dates": "Dates and time must follow the ISO8601 including time zone (YYYY-MM-DD or YYYY-MM-DDThh:mm:ss±hh)",
-    "units": "Use a space between numbers and units (100 m)",
-    "languages": "Languages must follow the IETF (BCP47) format (en-GB, en-US, de-DE)",
-    "licenses": "License name must follow the SPDX License List (https://spdx.org/licenses/)",
-    "review": "Following the OEP Data Review (https://github.com/OpenEnergyPlatform/data-preprocessing/wiki)",
-    "null": "If not applicable use (null)"} }
+                            "fields": [
+                                "id"
+                            ]
+                        }
+                    }
+                ],
+                "fields": [
+                    {
+                        "name": "id",
+                        "description": "Unique identifier",
+                        "type": "bigint",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "scenario_id",
+                        "description": "Scenario name",
+                        "type": "bigint",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "region",
+                        "description": "Country or region",
+                        "type": "text array",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "input_energy_vector",
+                        "description": "It describes any type of energy or energy carrier (e.g. electricity, heat, solar radiation, natural gas, ...) that enters a technology.",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "output_energy_vector",
+                        "description": "It describes any type of energy or energy carrier (e.g. electricity, heat, hydrogen, LNG, CO2, ...) that exits a technology.",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "parameter_name",
+                        "description": "It describes a considered property of an element in the energy system.",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "technology",
+                        "description": "It describes an element of the modelled energy system that processes an energy vector.",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "technology_type",
+                        "description": "The specification can be technological, or freely user-defined, based on the requirements of the model.",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "timeindex_start",
+                        "description": "Start timestamp",
+                        "type": "timestamp",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "timeindex_stop",
+                        "description": "Stop timestamp",
+                        "type": "timestamp",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "timeindex_resolution",
+                        "description": "Timesteps",
+                        "type": "interval",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "series",
+                        "description": "Timesteps",
+                        "type": "float array",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "unit",
+                        "description": "Parameter unit",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "tags",
+                        "description": "Free classification with key-value pairs",
+                        "type": "json",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "method",
+                        "description": "Method type (sum, mean, median)",
+                        "type": "json",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "source",
+                        "description": "Source",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    },
+                    {
+                        "name": "comment",
+                        "description": "Comment",
+                        "type": "text",
+                        "isAbout": [],
+                        "valueReference": []
+                    }
+                ]
+            },
+            "dialect": {
+                "delimiter": ";",
+                "decimalSeparator": "."
+            }
+        }
+    ],
+    "metaMetadata": {
+        "metadataVersion": "OEP-1.5.1",
+        "metadataLicense": {
+            "name": "CC0-1.0",
+            "title": "Creative Commons Zero v1.0 Universal",
+            "path": "https://creativecommons.org/publicdomain/zero/1.0/"
+        }
+    },
+    "_comment": {
+        "_comment": {
+            "metadata": "Metadata documentation and explanation (https://github.com/OpenEnergyPlatform/organisation/wiki/metadata)",
+            "dates": "Dates and time must follow the ISO8601 including time zone (YYYY-MM-DD or YYYY-MM-DDThh:mm:ss±hh)",
+            "units": "Use a space between numbers and units (100 m)",
+            "languages": "Languages must follow the IETF (BCP47) format (en-GB, en-US, de-DE)",
+            "licenses": "License name must follow the SPDX License List (https://spdx.org/licenses/)",
+            "review": "Following the OEP Data Review (https://github.com/OpenEnergyPlatform/data-preprocessing/wiki)",
+            "null": "If not applicable use: null",
+            "todo": "If a value is not yet available, use: todo"
+        }
+    }
+}

--- a/oedatamodel/latest/v111/datapackage/OEDataModel-normalization-datapackage/OEDataModel-normalization-datapackage.json
+++ b/oedatamodel/latest/v111/datapackage/OEDataModel-normalization-datapackage/OEDataModel-normalization-datapackage.json
@@ -1,31 +1,44 @@
-{"name": "Oedatamodel - General Energy Modell Datapackage",
+{
+    "name": "Oedatamodel - General Energy Modell Datapackage",
     "title": "OpenEnergyPlatform data format for scenario data",
-    "id": "",
+    "id": null,
     "description": "datamodel, metadata and examples provided as datapackage",
-    "language": ["en-GB"],
-    "keywords": ["datamodel", "datapackage", "genral energy dataformat"],
+    "language": [
+        "en-GB"
+    ],
+    "subject": [
+        {
+            "name": null,
+            "path": null
+        }
+    ],
+    "keywords": [
+        "datamodel",
+        "datapackage",
+        "genral energy dataformat"
+    ],
     "publicationDate": "2020-08-11",
-    "context":
-        {"homepage": "https://openenergy-platform.org/",
+    "context": {
+        "homepage": "https://openenergy-platform.org/",
         "documentation": "https://github.com/OpenEnergyPlatform/oedatamodel/blob/develop/README.md",
         "sourceCode": "https://github.com/OpenEnergyPlatform/oedatamodel/tree/develop/oedatamodel/latest",
-        "contact": "",
-        "grantNo": "",
-        "fundingAgency": "",
-        "fundingAgencyLogo": "",
-        "publisherLogo": ""},
-    "spatial":
-        {"location": "",
-        "extent": "",
-        "resolution": ""},
-    "temporal": 
-        {"referenceDate": "",
-        "timeseries": 
-            {"start": "",
-            "end": "",
-            "resolution": "",
-            "alignment": "",
-            "aggregationType": ""} },
+        "contact": "tbd@tbd.de",
+        "grantNo": null,
+        "fundingAgency": null,
+        "fundingAgencyLogo": null,
+        "publisherLogo": null
+    },
+    "spatial": {
+        "location": null,
+        "extent": null,
+        "resolution": null
+    },
+    "temporal": {
+        "timeseries": []
+    },
+    "review": {
+        "badge": null
+    },
     "sources": [
         {
             "title": "Open energy datamodel",
@@ -33,140 +46,687 @@
             "path": "https://github.com/OpenEnergyPlatform/oedatamodel/tree/develop/oedatamodel",
             "licenses": [
                 {
+                    "instruction": "You are free: To Share, To Create, To Adapt",
+                    "attribution": "© Reiner Lemoine Institut",
                     "name": "CC0-1.0",
                     "title": "Creative Commons Zero v1.0 Universal",
-                    "path": "https://creativecommons.org/publicdomain/zero/1.0/legalcode",
-                    "instruction": "You are free: To Share, To Create, To Adapt",
-                    "attribution": "© Reiner Lemoine Institut"
+                    "path": "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
                 }
             ]
-        }],
+        }
+    ],
     "licenses": [
         {
-            "name": "",
-            "title": "",
-            "path": "",
-            "instruction": "",
-            "attribution": ""
-        } 
+            "instruction": null,
+            "attribution": null,
+            "name": null,
+            "title": null,
+            "path": null
+        }
     ],
     "contributors": [
-        {"title": "jh-RLI", "email": null, "date": "2020-08-11", "object": "datapackage", "comment": "Create template datapackage for oedatamodel"},
-        {"title": "jh-RLI", "email": null, "date": "2020-10-08", "object": "metadata", "comment": "Fix links to documentation and source code"},
-        {"title": "jh-RLI", "email": null, "date": "2020-11-08", "object": "metadata", "comment": "Update Ressources"} ],
+        {
+            "title": "jh-RLI",
+            "object": "datapackage",
+            "comment": "Create template datapackage for oedatamodel",
+            "date": "2020-08-11"
+        },
+        {
+            "title": "jh-RLI",
+            "object": "metadata",
+            "comment": "Fix links to documentation and source code",
+            "date": "2020-10-08"
+        },
+        {
+            "title": "jh-RLI",
+            "object": "metadata",
+            "comment": "Update Ressources",
+            "date": "2020-11-08"
+        },
+        {
+            "title": "OMI",
+            "object": "Metadata conversion",
+            "comment": "Update metadata to oep-v1.5.1 using OMIs metadata conversion tool.",
+            "date": "2022-09-14"
+        }
+    ],
     "resources": [
-        {"profile": "tabular-data-resource",
-        "name": "model_draft.oed_scenario",
-        "path": "https://openenergy-platform.org/dataedit/view/model_draft/_prefix_oed_scenario",
-        "format": "PostgreSQL",
-        "encoding" : "UTF-8",
-        "schema": {
-            "fields": [
-                {"name": "id", "description": "Unique identifier", "type": "bigint", "unit": null},
-                {"name": "scenario", "description": "Scenario name", "type": "text", "unit": null},
-                {"name": "region", "description": "Country or region, you can add a upper region with sub regions using json syntax", "type": "json", "unit": null},
-                {"name": "year", "description": "Year", "type": "integer", "unit": null},
-                {"name": "source", "description": "Source", "type": "text", "unit": null},
-                {"name": "comment", "description": "Comment", "type": "text", "unit": null} ],
-            "primaryKey": ["id"],
-            "foreignKeys": [{
-                    "fields": [null],
-                    "reference": {
-                        "resource": null,
-                        "fields": [null] } } ] },
-        "dialect":
-            {"delimiter": ";",
-            "decimalSeparator": "."} },
-    
-        {"profile": "tabular-data-resource",
-        "name": "model_draft.oed_data",
-        "path": "https://openenergy-platform.org/dataedit/view/model_draft/_prefix_oed_data",
-        "format": "PostgreSQL",
-        "encoding" : "UTF-8",
-        "schema": {
-            "fields": [
-                {"name": "id", "description": "Unique identifier", "type": "bigint", "unit": null},
-                {"name": "scenario_id", "description": "Scenario name", "type": "bigint", "unit": null},
-                {"name": "region", "description": "Country or region, add a flow from region a -> b: ['a', 'b']", "type": "text array", "unit": null},
-                {"name": "input_energy_vector", "description": "It describes any type of energy or energy carrier (e.g. electricity, heat, solar radiation, natural gas, ...) that enters a technology.", "type": "text", "unit": null},
-                {"name": "output_energy_vector", "description": "It describes any type of energy or energy carrier (e.g. electricity, heat, hydrogen, LNG, CO2, ...) that exits a technology.", "type": "text", "unit": null},
-                {"name": "parameter_name", "description": "It describes a considered property of an element in the energy system.", "type": "text", "unit": null},
-                {"name": "technology", "description": "It describes an element of the modelled energy system that processes an energy vector.", "type": "text", "unit": null},
-                {"name": "technology_type", "description": "The specification can be technological, or freely user-defined, based on the requirements of the model.", "type": "text", "unit": null},
-                {"name": "type", "description": "value: scalar or timeseries indicate the related table", "type": "text", "unit": null},
-                {"name": "unit", "description": "Parameter unit", "type": "text", "unit": null},
-                {"name": "tags", "description": "Free classification with key-value pairs", "type": "json", "unit": null},
-                {"name": "method", "description": "Method type (sum, mean, median)", "type": "json", "unit": null},
-                {"name": "source", "description": "Source", "type": "text", "unit": null},
-                {"name": "comment", "description": "Comment", "type": "text", "unit": null}],
-            "primaryKey": ["id"],
-            "foreignKeys": [{
-                    "fields": ["scenario_id"],
-                    "reference": {
-                        "resource": "model_draft.oed_scenario",
-                        "fields": ["id"] } } ] },
-        
-        "dialect":
-            {"delimiter": ";",
-            "decimalSeparator": "."} },
-    
-        {"profile": "tabular-data-resource",
-        "name": "model_draft.oed_scalar",
-        "path": "https://openenergy-platform.org/dataedit/view/model_draft/_prefix_oed_scalar",
-        "format": "PostgreSQL",
-        "encoding" : "UTF-8",
-        "schema": {
-            "fields": [
-                {"name": "id", "description": "Unique identifier", "type": "bigint", "unit": null},
-                {"name": "year", "description": "Year", "type": "integer", "unit": null},
-                {"name": "value", "description": "Value", "type": "float", "unit": "kw"} ],
-            "primaryKey": ["id"],
-            "foreignKeys": [{
-                    "fields": ["id"],
-                    "reference": {
-                        "resource": "model_draft.oed_data",
-                        "fields": ["id"] } } ] },
-        "dialect":
-            {"delimiter": ";",
-            "decimalSeparator": "."} },
-    
-        {"profile": "tabular-data-resource",
+        {
+            "profile": "tabular-data-resource",
+            "name": "model_draft.oed_scenario",
+            "path": "https://openenergy-platform.org/dataedit/view/model_draft/_prefix_oed_scenario",
+            "format": "PostgreSQL",
+            "encoding": "UTF-8",
+            "schema": {
+                "primaryKey": [
+                    "id"
+                ],
+                "foreignKeys": [],
+                "fields": [
+                    {
+                        "name": "id",
+                        "description": "Unique identifier",
+                        "type": "bigint",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "scenario",
+                        "description": "Scenario name",
+                        "type": "text",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "region",
+                        "description": "Country or region, you can add a upper region with sub regions using json syntax",
+                        "type": "json",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "year",
+                        "description": "Year",
+                        "type": "integer",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "source",
+                        "description": "Source",
+                        "type": "text",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "comment",
+                        "description": "Comment",
+                        "type": "text",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    }
+                ]
+            },
+            "dialect": {
+                "delimiter": ";",
+                "decimalSeparator": "."
+            }
+        },
+        {
+            "profile": "tabular-data-resource",
+            "name": "model_draft.oed_data",
+            "path": "https://openenergy-platform.org/dataedit/view/model_draft/_prefix_oed_data",
+            "format": "PostgreSQL",
+            "encoding": "UTF-8",
+            "schema": {
+                "primaryKey": [
+                    "id"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": [
+                            "scenario_id"
+                        ],
+                        "reference": {
+                            "resource": "model_draft.oed_scenario",
+                            "fields": [
+                                "id"
+                            ]
+                        }
+                    }
+                ],
+                "fields": [
+                    {
+                        "name": "id",
+                        "description": "Unique identifier",
+                        "type": "bigint",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "scenario_id",
+                        "description": "Scenario name",
+                        "type": "bigint",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "region",
+                        "description": "Country or region, add a flow from region a -> b: ['a', 'b']",
+                        "type": "text array",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "input_energy_vector",
+                        "description": "It describes any type of energy or energy carrier (e.g. electricity, heat, solar radiation, natural gas, ...) that enters a technology.",
+                        "type": "text",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "output_energy_vector",
+                        "description": "It describes any type of energy or energy carrier (e.g. electricity, heat, hydrogen, LNG, CO2, ...) that exits a technology.",
+                        "type": "text",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "parameter_name",
+                        "description": "It describes a considered property of an element in the energy system.",
+                        "type": "text",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "technology",
+                        "description": "It describes an element of the modelled energy system that processes an energy vector.",
+                        "type": "text",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "technology_type",
+                        "description": "The specification can be technological, or freely user-defined, based on the requirements of the model.",
+                        "type": "text",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "type",
+                        "description": "value: scalar or timeseries indicate the related table",
+                        "type": "text",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "unit",
+                        "description": "Parameter unit",
+                        "type": "text",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "tags",
+                        "description": "Free classification with key-value pairs",
+                        "type": "json",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "method",
+                        "description": "Method type (sum, mean, median)",
+                        "type": "json",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "source",
+                        "description": "Source",
+                        "type": "text",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "comment",
+                        "description": "Comment",
+                        "type": "text",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    }
+                ]
+            },
+            "dialect": {
+                "delimiter": ";",
+                "decimalSeparator": "."
+            }
+        },
+        {
+            "profile": "tabular-data-resource",
+            "name": "model_draft.oed_scalar",
+            "path": "https://openenergy-platform.org/dataedit/view/model_draft/_prefix_oed_scalar",
+            "format": "PostgreSQL",
+            "encoding": "UTF-8",
+            "schema": {
+                "primaryKey": [
+                    "id"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": [
+                            "id"
+                        ],
+                        "reference": {
+                            "resource": "model_draft.oed_data",
+                            "fields": [
+                                "id"
+                            ]
+                        }
+                    }
+                ],
+                "fields": [
+                    {
+                        "name": "id",
+                        "description": "Unique identifier",
+                        "type": "bigint",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "year",
+                        "description": "Year",
+                        "type": "integer",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "value",
+                        "description": "Value",
+                        "type": "float",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "unit": "kw"
+                    }
+                ]
+            },
+            "dialect": {
+                "delimiter": ";",
+                "decimalSeparator": "."
+            }
+        },
+        {
+            "profile": "tabular-data-resource",
             "name": "model_draft.oed_timeseries",
             "path": "https://openenergy-platform.org/dataedit/view/model_draft/_prefix_oed_timeseries",
             "format": "PostgreSQL",
-            "encoding" : "UTF-8",
+            "encoding": "UTF-8",
             "schema": {
-                "fields": [
-                    {"name": "id", "description": "Unique identifier", "type": "bigint", "unit": null},
-                    {"name": "timeindex_start", "description": "Start timestemp", "type": "timestamp", "unit": null},
-                    {"name": "timeindex_stop", "description": "Stop timestemp", "type": "timestamp", "unit": null},
-                    {"name": "timeindex_resolution", "description": "Timesteps", "type": "interval", "unit": null},
-                    {"name": "series", "description": "Timesteps", "type": "float array", "unit": null} ],
-                "primaryKey": ["data_id"],
-                "foreignKeys": [{
-                        "fields": ["id"],
+                "primaryKey": [
+                    "data_id"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": [
+                            "id"
+                        ],
                         "reference": {
                             "resource": "model_draft.oed_data",
-                            "fields": ["id"] } } ] },
-            "dialect":
-                {"delimiter": ";",
-                "decimalSeparator": "."} } ],
-    
-    "review": {
-        "path": null,
-        "badge": null
-    },
-    "metaMetadata":
-        {"metadataVersion": "OEP-1.4.0",
-        "metadataLicense":
-            {"name": "CC0-1.0",
+                            "fields": [
+                                "id"
+                            ]
+                        }
+                    }
+                ],
+                "fields": [
+                    {
+                        "name": "id",
+                        "description": "Unique identifier",
+                        "type": "bigint",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "timeindex_start",
+                        "description": "Start timestemp",
+                        "type": "timestamp",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "timeindex_stop",
+                        "description": "Stop timestemp",
+                        "type": "timestamp",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "timeindex_resolution",
+                        "description": "Timesteps",
+                        "type": "interval",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "series",
+                        "description": "Timesteps",
+                        "type": "float array",
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    }
+                ]
+            },
+            "dialect": {
+                "delimiter": ";",
+                "decimalSeparator": "."
+            }
+        }
+    ],
+    "metaMetadata": {
+        "metadataVersion": "OEP-1.5.1",
+        "metadataLicense": {
+            "name": "CC0-1.0",
             "title": "Creative Commons Zero v1.0 Universal",
-            "path": "https://creativecommons.org/publicdomain/zero/1.0/"} },
-    "_comment":
-        {"metadata": "Metadata documentation and explanation (https://github.com/OpenEnergyPlatform/organisation/wiki/metadata)",
-        "dates": "Dates and time must follow the ISO8601 including time zone (YYYY-MM-DD or YYYY-MM-DDThh:mm:ss±hh)",
-        "units": "Use a space between numbers and units (100 m)",
-        "languages": "Languages must follow the IETF (BCP47) format (en-GB, en-US, de-DE)",
-        "licenses": "License name must follow the SPDX License List (https://spdx.org/licenses/)",
-        "review": "Following the OEP Data Review (https://github.com/OpenEnergyPlatform/data-preprocessing/wiki)",
-        "null": "If not applicable use (null)"} }
+            "path": "https://creativecommons.org/publicdomain/zero/1.0/"
+        }
+    },
+    "_comment": {
+        "_comment": {
+            "metadata": "Metadata documentation and explanation (https://github.com/OpenEnergyPlatform/organisation/wiki/metadata)",
+            "dates": "Dates and time must follow the ISO8601 including time zone (YYYY-MM-DD or YYYY-MM-DDThh:mm:ss±hh)",
+            "units": "Use a space between numbers and units (100 m)",
+            "languages": "Languages must follow the IETF (BCP47) format (en-GB, en-US, de-DE)",
+            "licenses": "License name must follow the SPDX License List (https://spdx.org/licenses/)",
+            "review": "Following the OEP Data Review (https://github.com/OpenEnergyPlatform/data-preprocessing/wiki)",
+            "null": "If not applicable use: null",
+            "todo": "If a value is not yet available, use: todo"
+        }
+    }
+}


### PR DESCRIPTION
Since @areleu contributed a new github workflow and test files, we can now validate the data package json files based on the latest schema from the oemetadata repository. . Thi has presented some issues with the current data package files and the oemetadata schema itself. The schema has been updated in the oemetadata repo. (latest). This PR provides the updated data package json files for both oed variants. 